### PR TITLE
Made tardis -h return a zero exitcode, since it is not an error.

### DIFF
--- a/tardis/run.py
+++ b/tardis/run.py
@@ -210,6 +210,9 @@ def tardis_main(argv=None):
 
     try:
         (options,toolargs) = tutils.getOptions(argv)
+    except tutils.Help, msg:
+        print >> sys.stderr, msg
+        return 0
     except tutils.Usage, msg:
         print >> sys.stderr, msg
         return 2

--- a/tardis/tutils/tutils.py
+++ b/tardis/tutils/tutils.py
@@ -65,11 +65,16 @@ def fastqPairedNamesEqual(name1, name2):
                     return True
 
         return False
-    
+
 
 class Usage(Exception):
     def __init__(self, msg):
         super(Usage, self).__init__(msg)
+
+class Help(Exception):
+    """Triggers a non-error usage message."""
+    def __init__(self, msg):
+        super(Help, self).__init__(msg)
 
 def getDefaultEngineOptions():
     """
@@ -621,7 +626,7 @@ local which results in each job being launched by tardis itself on the local mac
         elif arg == "-batonfile" :
             checkAndSetOption(options,"batonfile",args.pop(0))
         elif arg == "-h":
-            raise Usage(usage)
+            raise Help(usage)
         elif " " in arg:
             args.insert('"%s"' % arg) # ref /home/galaxy/galaxy/tools/ncbi_blast_plus/hide_stderr.py
         else:


### PR DESCRIPTION
Conda packaging requires to be able to run tardis trivially, to test
installation, and get a non error result.